### PR TITLE
Add corejs to dev dependencies for serving libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@angular/platform-browser-dynamic": "^7.0.0",
     "@angular/router": "^7.0.0",
     "@blackbaud/auth-client": "^2.0.0",
+    "core-js": "^2.6.9",
     "@pact-foundation/pact-web": "^7.4.0",
     "@skyux-sdk/builder": "^3.0.0",
     "@skyux-sdk/builder-plugin-skyux": "^1.0.0",


### PR DESCRIPTION
Mirrors a change to the skyux-spa template made here: https://github.com/blackbaud/skyux-sdk-template/pull/8