### PR TITLE
alphabetize props (next schema ver will recommend)

### DIFF
--- a/skyuxconfig.json
+++ b/skyuxconfig.json
@@ -1,15 +1,15 @@
 {
   "$schema": "./node_modules/@skyux/config/skyuxconfig-schema.json",
-  "mode": "easy",
-  "compileMode": "aot",
-  "plugins": [
-    "@skyux-sdk/builder-plugin-skyux"
-  ],
   "appSettings": {
     "myLibrary": {
       "name": "My Library"
     }
   },
+  "compileMode": "aot",
+  "mode": "easy",
+  "plugins": [
+    "@skyux-sdk/builder-plugin-skyux"
+  ],
   "testSettings": {
     "unit": {
       "browserSet": "paranoid"


### PR DESCRIPTION
This is from a discussion a few weeks ago with @Blackbaud-BobbyEarl....just an update of the order in which the template lists properties in the skyuxconfig (Bobby noted that the next version of the schema will recommend alpha order as well)